### PR TITLE
fix: display correct error message in login page

### DIFF
--- a/src/features/auth/login/index.tsx
+++ b/src/features/auth/login/index.tsx
@@ -102,7 +102,14 @@ export const Login = () => {
       setLocalToken(responseJson.token);
       window.location.replace("/");
     } catch (err: any) {
+      try {
+      const errorJson = await err.json();
+      setLoginError(errorJson?.title || "Login failed. Please try again.");
+      return;
+      } catch {
       setLoginError("Login failed. Please try again.");
+      return;
+      } 
     } finally {
       setLoading(false);
     }

--- a/src/providers/request-provider.tsx
+++ b/src/providers/request-provider.tsx
@@ -34,6 +34,7 @@ class ApiExtended<getTokenFn> extends Api<getTokenFn> {
             }
             throw e;
           }
+            throw e;
         }
       };
     });


### PR DESCRIPTION
Display the error message according to the message sent by the backend.