### PR TITLE
fix/108/rmved the redundant <Card /> cmp

### DIFF
--- a/src/components/generic-components/generic-form.tsx
+++ b/src/components/generic-components/generic-form.tsx
@@ -492,9 +492,6 @@ export function GenericForm<TView extends BasicTypeForGeneric, TCreate, TUpdate>
           )}
         </CardContent>
       </Card>
-      <Card>
-        <CardContent></CardContent>
-      </Card>
     </>
   );
 }


### PR DESCRIPTION
identifed hr-tag in not actually an element. its the gap between two div-tags (Card-component) tags -> combination of box shadows were displayed as a horizontal line