### PR TITLE
fix/115/prf menu <ul /> & respective child tags refined

### DIFF
--- a/src/components/app-header/dropdown-menu/index.tsx
+++ b/src/components/app-header/dropdown-menu/index.tsx
@@ -14,6 +14,13 @@ import { useUserInfo } from "@providers/user-provider";
 import { buildAbsoluteUrl } from "@lib/network/utils";
 import { useAuthState } from "@providers/auth-provider";
 import { useNavigate } from "react-router-dom";
+import { styled } from "@mui/material";
+
+export const AccountMenu = styled("ul")`
+  width: 32px;
+  height: 32px;
+  display: flex;
+`;
 
 export const DropdownMenu = () => {
   const { logout } = useAuthState();
@@ -62,6 +69,33 @@ export const DropdownMenu = () => {
         open={open}
         onClose={handleClose}
         onClick={handleClose}
+        sx={{
+          // <hr /> tag/s
+          "& .MuiDivider-root": {
+            margin: "0% !important",
+          },
+          // main <ul />
+          "& .MuiList-root": {
+            padding: "0% !important",
+          },
+          // <li /> tags
+          "& .MuiMenuItem-root": {
+            // <li /> tags between the first & last
+            padding: "8px 16px",
+
+            "&:hover": {
+              backgroundColor: "rgba(0, 0, 0, 0.05)",
+            },
+            // first <li />
+            "&:first-of-type": {
+              padding: "10px 16px 8px",
+            },
+            // last <li />
+            "&:last-of-type": {
+              padding: "8px 16px 10px",
+            },
+          },
+        }}
       >
         <MenuItem onClick={handleProfileClick} disabled={userInfo === null}>
           <Avatar
@@ -73,6 +107,12 @@ export const DropdownMenu = () => {
           Profile
         </MenuItem>
         <Divider />
+        <MenuItem onClick={logout} disabled={userInfo === null}>
+          <ListItemIcon>
+            <LogOut size={20} />
+          </ListItemIcon>
+          Logout
+        </MenuItem>
         <MenuItem onClick={logout} disabled={userInfo === null}>
           <ListItemIcon>
             <LogOut size={20} />

--- a/src/components/app-header/dropdown-menu/index.tsx
+++ b/src/components/app-header/dropdown-menu/index.tsx
@@ -35,7 +35,7 @@ export const DropdownMenu = () => {
     setAnchorElement(null);
   };
 
-  const handleProfileClick = () => {
+  const handleProfileClick: () => void = () => {
     navigate("/users/me/edit");
   };
 

--- a/src/components/app-header/dropdown-menu/index.tsx
+++ b/src/components/app-header/dropdown-menu/index.tsx
@@ -14,13 +14,7 @@ import { useUserInfo } from "@providers/user-provider";
 import { buildAbsoluteUrl } from "@lib/network/utils";
 import { useAuthState } from "@providers/auth-provider";
 import { useNavigate } from "react-router-dom";
-import { styled } from "@mui/material";
-
-export const AccountMenu = styled("ul")`
-  width: 32px;
-  height: 32px;
-  display: flex;
-`;
+import { AccountMenu } from "../index.styled";
 
 export const DropdownMenu = () => {
   const { logout } = useAuthState();
@@ -63,39 +57,12 @@ export const DropdownMenu = () => {
           </IconButton>
         </Tooltip>
       </Box>
-      <Menu
+      <AccountMenu
         anchorEl={anchorElement}
         id="account-menu"
         open={open}
         onClose={handleClose}
         onClick={handleClose}
-        sx={{
-          // <hr /> tag/s
-          "& .MuiDivider-root": {
-            margin: "0% !important",
-          },
-          // main <ul />
-          "& .MuiList-root": {
-            padding: "0% !important",
-          },
-          // <li /> tags
-          "& .MuiMenuItem-root": {
-            // <li /> tags between the first & last
-            padding: "8px 16px",
-
-            "&:hover": {
-              backgroundColor: "rgba(0, 0, 0, 0.05)",
-            },
-            // first <li />
-            "&:first-of-type": {
-              padding: "10px 16px 8px",
-            },
-            // last <li />
-            "&:last-of-type": {
-              padding: "8px 16px 10px",
-            },
-          },
-        }}
       >
         <MenuItem onClick={handleProfileClick} disabled={userInfo === null}>
           <Avatar
@@ -113,13 +80,7 @@ export const DropdownMenu = () => {
           </ListItemIcon>
           Logout
         </MenuItem>
-        <MenuItem onClick={logout} disabled={userInfo === null}>
-          <ListItemIcon>
-            <LogOut size={20} />
-          </ListItemIcon>
-          Logout
-        </MenuItem>
-      </Menu>
+      </AccountMenu>
     </React.Fragment>
   );
 };

--- a/src/components/app-header/index.styled.tsx
+++ b/src/components/app-header/index.styled.tsx
@@ -1,4 +1,4 @@
-import { AppBar, styled, Toolbar } from "@mui/material";
+import { AppBar, Menu, MenuProps, styled, Toolbar } from "@mui/material";
 
 export const AppBarStyled = styled(AppBar)`
   position: sticky;
@@ -13,6 +13,37 @@ export const AppBarStyled = styled(AppBar)`
   display: flex;
   justify-content: center;
 `;
+
+export const AccountMenu = styled((props: MenuProps) => <Menu {...props} />)(({ theme }) => ({
+  "& .MuiPaper-root": {
+    borderRadius: theme.shape.borderRadius,
+    marginTop: theme.spacing(1),
+    minWidth: 180,
+    boxShadow: "rgb(0 0 0 / 20%) 0px 2px 10px",
+
+    "& .MuiDivider-root": {
+      margin: "0 !important",
+    },
+    "& .MuiList-root": {
+      padding: "0 !important",
+    },
+    "& .MuiMenuItem-root": {
+      padding: "8px 16px",
+
+      "&:hover": {
+        backgroundColor: "rgba(0, 0, 0, 0.05)",
+      },
+
+      "&:first-of-type": {
+        padding: "10px 16px 8px",
+      },
+
+      "&:last-of-type": {
+        padding: "8px 16px 10px",
+      },
+    },
+  },
+}));
 
 export const AppBarToolbar = styled(Toolbar)`
   min-height: 64px;


### PR DESCRIPTION
cause: prf component (ul-tag) top & bottom paddings were collided with the child elements (li-tag) own padding values. the divisor margins was also miss-aligned

refinement:
- removed all padding values from main container (ul-tag)
- removed the margin values from the divisor (hr-tag)
- increased the child tags hovering visibility/contrast by +0.01(alpha-only) in the RGBa scale
- gave a general padding to all children elms
- replace all the padding values from first & last li-tag to be match with container